### PR TITLE
Fix nullable transformable properties handling

### DIFF
--- a/src/Reflection/Types/PropertyTypeFactory.php
+++ b/src/Reflection/Types/PropertyTypeFactory.php
@@ -88,7 +88,7 @@ class PropertyTypeFactory
 
         return new TransformableType(
             $type,
-            $isScalar,
+            $isNullable,
         );
     }
 }

--- a/tests/Integration/ClassTransformerFromArrayTest.php
+++ b/tests/Integration/ClassTransformerFromArrayTest.php
@@ -18,6 +18,7 @@ use Tests\Integration\DTO\ArrayScalarDTO;
 use Tests\Integration\DTO\UserEmptyTypeDTO;
 use ClassTransformer\Exceptions\ClassNotFoundException;
 
+use Tests\Integration\DTO\UserNullableArrayDTO;
 use function count;
 
 /**
@@ -220,5 +221,29 @@ class ClassTransformerFromArrayTest extends TestCase
         self::assertEquals($data['id'], $userDTO->id);
         self::assertEquals($data['email'], $userDTO->email);
         self::assertEquals($data['balance'], $userDTO->balance);
+    }
+
+    public function testNullableTransformableProperty(): void
+    {
+        $data = [
+            'user' => null,
+        ];
+
+        $userNullableDTO = Hydrator::init()->create(UserNullableArrayDTO::class, $data);
+
+        self::assertInstanceOf(UserNullableArrayDTO::class, $userNullableDTO);
+        self::assertNull($userNullableDTO->user);
+    }
+
+    public function testNotNullableTransformableProperty(): void
+    {
+        $data = [
+            'user' => $this->getBaseArrayData(),
+        ];
+
+        $userNullableDTO = Hydrator::init()->create(UserNullableArrayDTO::class, $data);
+
+        self::assertInstanceOf(UserNullableArrayDTO::class, $userNullableDTO);
+        self::assertInstanceOf(UserDTO::class, $userNullableDTO->user);
     }
 }

--- a/tests/Integration/DTO/UserNullableArrayDTO.php
+++ b/tests/Integration/DTO/UserNullableArrayDTO.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Integration\DTO;
+
+class UserNullableArrayDTO
+{
+    public ?UserDTO $user;
+}

--- a/tests/Units/DTO/TypesDto.php
+++ b/tests/Units/DTO/TypesDto.php
@@ -16,5 +16,5 @@ class TypesDto
     public ?string $emptyString;
     public ?float $nullableFloat;
     public ?bool $nullableBool;
-
+    public ?UserDTO $nullableObject;
 }

--- a/tests/Units/ValueCastingTest.php
+++ b/tests/Units/ValueCastingTest.php
@@ -79,6 +79,10 @@ class ValueCastingTest extends TestCase
         $value = $caster->castAttribute(null);
         $this->assertNull($value);
         
+        $caster = new ValueCasting(new RuntimeReflectionProperty(new \ReflectionProperty(TypesDto::class, 'nullableObject')));
+        $value = $caster->castAttribute(null);
+        $this->assertNull($value);
+        
     }
 
     public function testCreateArrayProperty(): void


### PR DESCRIPTION
Fix the issue #14 

## Issue Description

There was an issue with transforming nullable transformable properties (like DTO objects) when `null` values were provided. Instead of preserving the `null` value, the system was incorrectly creating an empty instance of the class.

## How to reproduce

```
class ProductDTO
{
    public int $id;
    public string $name;
}

class DiscountDTO
{
    public string $code;
    public int $value;
}

class PurchaseDTO
{
    public ProductDTO $product;
    public ?DiscountDTO $discount;
    public float $cost;
}

$data = [
    'product' => ['id' => 1, 'name' => 'phone'],
    'discount' => null,
    'cost' => 10012.23,
];

$purchaseDTO = ClassTransformer\Hydrator::init()->create(PurchaseDTO::class, $data);
var_dump($purchaseDTO->discount);
```

## Expected behavior

The `$purchaseDTO->discount` property should be `null` since we provided `null` in the input data and the property is nullable (`?DiscountDTO`).

## Actual behavior

The system was creating an empty DiscountDTO object:

```
object(DiscountDTO)#34 (0) {
  ["code"]=>
  uninitialized(string)
  ["value"]=>
  uninitialized(int)
}
```

## Fix
The issue was in the `PropertyTypeFactory::create()` method, where the wrong parameter was being passed to the 
`TransformableType` constructor. The method was passing the `$isScalar` flag instead of the `$isNullable` flag, causing the nullable information to be lost during transformation.

This PR fixes the issue by passing the correct `$isNullable` parameter to ensure that nullable properties remain `null` when `null` values are provided.

## Tests

Added a test condition to `ValueCastingTest` and new test cases to `ClassTransformerFromArrayTest` that verify:

1. Nullable properties correctly remain `null` when `null` is provided
2. Nullable properties are correctly transformed when valid data is provided